### PR TITLE
Updated to use `pipes-4.0.0`

### DIFF
--- a/daemons.cabal
+++ b/daemons.cabal
@@ -39,7 +39,7 @@ Library
   Hs-Source-Dirs:       src
   Build-depends:        base >= 4 && < 5, bytestring, cereal,
                         data-default, directory, filepath, ghc-prim, network,
-                        pipes >= 3.1,
+                        pipes >= 4.0.0,
                         transformers, unix
   Ghc-options:          -Wall
   Exposed-modules:      Control.Pipe.C3,
@@ -63,7 +63,7 @@ Executable addone
 Executable queue
   Build-depends:        base >= 4 && < 5, bytestring, cereal, containers,
                         daemons, data-default, ghc-prim, network,
-                        pipes >= 3.1, transformers
+                        pipes >= 4.0.0, transformers
   Main-Is:              examples/Queue.hs
   Ghc-options:          -Wall
 

--- a/src/Control/Pipe/C3.hs
+++ b/src/Control/Pipe/C3.hs
@@ -5,20 +5,20 @@ module Control.Pipe.C3 (
 
 import Control.Monad ( forever )
 import Control.Monad.Trans.Class ( lift )
-import Control.Pipe ( runPipe, await, yield, (<+<) )
 import Control.Pipe.Serialize ( serializer, deserializer )
 import Control.Pipe.Socket ( Handler )
 import Data.Serialize ( Serialize )
+import Pipes ( runEffect, await, yield, (<-<) )
 
 -- | Send a single command over the outgoing pipe and wait for a
 -- response.  If the incoming pipe is closed before a response
 -- arrives, returns @Nothing@.
 commandSender :: (Serialize a, Serialize b) => a -> Handler (Maybe b)
-commandSender command reader writer = do
-    runPipe (writer <+< serializer <+< sendCommand)
-    runPipe (receiveResponse
-             <+< (deserializer >> return Nothing)
-             <+< (reader >> return Nothing))
+commandSender command reader writer = runEffect $ do
+    writer <-< serializer <-< sendCommand
+    receiveResponse
+        <-< (deserializer >> return Nothing)
+        <-< (reader >> return Nothing)
   where
     sendCommand = do
         yield command
@@ -30,10 +30,8 @@ commandSender command reader writer = do
 -- | Wait for commands on the incoming pipe, handle them, and send the
 -- reponses over the outgoing pipe.
 commandReceiver :: (Serialize a, Serialize b) => (a -> IO b) -> Handler ()
-commandReceiver executeCommand reader writer = do
-    runPipe (writer <+< serializer
-             <+< commandExecuter
-             <+< deserializer <+< reader)
+commandReceiver executeCommand reader writer = runEffect $
+    writer <-< serializer <-< commandExecuter <-< deserializer <-< reader
   where
     commandExecuter = forever $ do
         comm <- await

--- a/src/Control/Pipe/Serialize.hs
+++ b/src/Control/Pipe/Serialize.hs
@@ -24,7 +24,7 @@ module Control.Pipe.Serialize (
 import Data.ByteString.Char8 ( ByteString )
 import Data.Serialize ( Serialize, get, encode
                       , Result(..), runGetPartial )
-import Control.Pipe ( Pipe, await, yield )
+import Pipes ( Pipe, await, yield )
 import Control.Monad ( forever )
 
 -- | De-serialize data from strict 'ByteString's.  Uses @cereal@'s

--- a/src/Control/Pipe/Socket.hs
+++ b/src/Control/Pipe/Socket.hs
@@ -16,12 +16,12 @@ import qualified Control.Exception as CE
 import Control.Monad ( forever, unless )
 import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.Trans.Class ( lift )
-import Control.Pipe ( Consumer, Producer, await, yield )
 import Data.ByteString.Char8 ( ByteString )
 import qualified Data.ByteString.Char8 as B
 import Network.Socket ( Socket )
 import qualified Network.Socket as NS
 import Network.Socket.ByteString ( sendAll, recv )
+import Pipes ( Consumer, Producer, await, yield )
 
 -- | Stream data from the socket.
 socketReader :: (MonadIO m) => Socket -> Producer ByteString m ()


### PR DESCRIPTION
This upgrades the code to compile against `pipes-4.0.0`.

I wasn't sure whether or not you wanted to rename the `Control.Pipe.*` modules to `Pipes.*` so I just left them as is.
