### PR TITLE
Fix build with GHC 8.8

### DIFF
--- a/src/Control/Pipe/Serialize.hs
+++ b/src/Control/Pipe/Serialize.hs
@@ -26,10 +26,11 @@ import Data.Serialize ( Serialize, get, encode
                       , Result(..), runGetPartial )
 import Pipes ( Pipe, await, yield )
 import Control.Monad ( forever )
+import Control.Monad.Fail ( MonadFail )
 
 -- | De-serialize data from strict 'ByteString's.  Uses @cereal@'s
 -- incremental 'Data.Serialize.Get' parser.
-deserializer :: (Serialize a, Monad m) => Pipe ByteString a m ()
+deserializer :: (Serialize a, Monad m, MonadFail m) => Pipe ByteString a m ()
 deserializer = loop Nothing Nothing
   where
     loop mk mbin = do

--- a/src/Control/Pipe/Socket.hs
+++ b/src/Control/Pipe/Socket.hs
@@ -70,7 +70,7 @@ runSocketServer lsocket handler = liftIO $ forever $ do
     (socket, _addr) <- NS.accept lsocket
     _ <- forkIO $ CE.finally
                       (handler (socketReader socket) (socketWriter socket))
-                      (NS.sClose socket)
+                      (NS.close socket)
     return ()
 
 -- | Run 'Handler' on the given socket.


### PR DESCRIPTION
This PR closes #8, and means that `daemons` now support GHC 8.8.

In order to do that, I had to:

- Add a `MonadFail` instance (needed for `Pipe`) on one function and add the associated import to keep compatibility with GHC 8.6
- Add support for newest `network` library. The API changed a bit and some function were deprecated.

The compatibility with older GHC version is done. I tested the build using the following nix expression:

```nix
with import <nixpkgs> {};
let
  makeDaemons = haskellPackages: networkName: haskellPackages.callCabal2nix "daemons"
    (builtins.filterSource (type: name: name != "default.nix") ./.)
    {
      network = builtins.getAttr networkName haskellPackages;
    };

  haskellCompilers = with haskell.packages; [ ghc882 ghc865 ghc844 ];
  # "network" is:
  # - 2.8.0.1 for ghc 8.6 and ghc 8.4
  # - 3.1.1.1 for ghc 8.8
  networkPackages = ["network" "network_3_0_1_1" "network_3_1_1_1"];

in lib.lists.crossLists (hs: network: makeDaemons hs network) [ haskellCompilers networkPackages ]
```

Meaning that I tested with ghc 8.4, 8.6 and 8.8. With `network` 3.0, 3.1 and 2.8 (except for ghc 8.8).

If accepted, could you do an hackage release? I suggest upgrading the major version number, considering that the API changed to add the `MonadFail` constraint. 